### PR TITLE
Add property to hide loading spinner

### DIFF
--- a/Source/JTSImageViewController.h
+++ b/Source/JTSImageViewController.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSInteger, JTSImageViewControllerBackgroundStyle) {
 
 @property (strong, nonatomic, readonly) JTSImageInfo *imageInfo;
 @property (strong, nonatomic, readonly) UIImage *image;
+@property (nonatomic) BOOL hideSpinner; // hide the first loading indicator
 @property (copy, nonatomic, readwrite) NSString *accessibilityLabel;
 @property (copy, nonatomic, readwrite) NSString *accessibilityHintZoomedIn;
 @property (copy, nonatomic, readwrite) NSString *accessibilityHintZoomedOut;

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -102,6 +102,7 @@
         _accessibilityLabel = [self defaultAccessibilityLabelForScrollView];
         _accessibilityHintZoomedIn = [self defaultAccessibilityHintForScrollView:YES];
         _accessibilityHintZoomedOut = [self defaultAccessibilityHintForScrollView:NO];
+        self.hideSpinner = NO;
         if (_mode == JTSImageViewControllerMode_Image) {
             [self setupImageAndDownloadIfNecessary:imageInfo];
         }
@@ -321,10 +322,14 @@
     self.progressView.center = CGPointMake(64.0f, 64.0f);
     self.progressView.alpha = 0;
     [self.progressContainer addSubview:self.progressView];
-    self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
-    self.spinner.center = CGPointMake(64.0f, 64.0f);
-    [self.spinner startAnimating];
-    [self.progressContainer addSubview:self.spinner];
+    
+    if (self.hideSpinner==NO) {
+        self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+        self.spinner.center = CGPointMake(64.0f, 64.0f);
+        [self.spinner startAnimating];
+        [self.progressContainer addSubview:self.spinner];
+    }
+    
     [self.progressContainer setAlpha:0];
     
     self.animator = [[UIDynamicAnimator alloc] initWithReferenceView:self.scrollView];


### PR DESCRIPTION
During some of my testing with `JTSImageViewController`, the spinner just comes in and out very fast so hiding it can improve the user experience. 

``` objc
JTSImageViewController *imageViewer = [[JTSImageViewController alloc] init...
imageViewer.hideSpinner = YES; // optionally hide the loading spinner
[imageViewer show...
```

Thanks for your work.
