### PR TITLE
Fixed bug with crashing on some gifs.

### DIFF
--- a/Source/JTSAnimatedGIFUtility.m
+++ b/Source/JTSAnimatedGIFUtility.m
@@ -57,6 +57,8 @@ static int sum(size_t const count, int const *const values) {
 }
 
 static int pairGCD(int a, int b) {
+    if (b == 0)
+        return a;
     if (a < b)
         return pairGCD(b, a);
     while (true) {


### PR DESCRIPTION
The problem was with "static int pairGCD(int a, int b)" method.
Elements of the array values[] can be equal to 0 or greater, so if we counted GCD of (a, 0) - there was a crash.

There are 3 variants with 0:
a == 0 and b != 0;
a != 0 and b == 0;
a == 0 and b == 0;
I add one line to avoid crash:
if (b == 0)
        return a;
It covers all variants, because later in code we have line that compare 2 elements and swap them if (a < b) - it will call "pairGCD(b, a)" and 0 - is the smallest possible number.
