### PR TITLE
Use UIViewContentMode if specified

### DIFF
--- a/Source/JTSImageInfo.h
+++ b/Source/JTSImageInfo.h
@@ -18,6 +18,7 @@
 @property (copy, nonatomic) NSString *title;
 @property (assign, nonatomic) CGRect referenceRect;
 @property (strong, nonatomic) UIView *referenceView;
+@property (assign, nonatomic) UIViewContentMode contentMode;
 @property (copy, nonatomic) NSMutableDictionary *userInfo;
 
 - (NSString *)displayableTitleAltTextSummary;

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -474,6 +474,10 @@ typedef struct {
     
     _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation = [self.view convertRect:referenceFrameInWindow fromView:nil];
     
+    if (self.imageInfo.contentMode) {
+        self.imageView.contentMode = self.imageInfo.contentMode;
+    }
+    
     // This will be moved into the scroll view after
     // the transition finishes.
     [self.view addSubview:self.imageView];


### PR DESCRIPTION
My source UIImageView is using `UIViewContentModeScaleAspectFit` which looks silly during the transition if the image is bigger than the frame. 

This allows the user to specify the contentMode.
