### PR TITLE
Fixed iOS 8 Double Tap Flicker

### DIFF
--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -673,13 +673,14 @@ UIGestureRecognizerDelegate
     
     [self.scrollView addSubview:self.imageView];
     
+    [self.scrollView setAlpha:0];
+    
     [viewController presentViewController:self animated:NO completion:^{
         
         if ([UIApplication sharedApplication].statusBarOrientation != _startingInfo.startingInterfaceOrientation) {
             _startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation = YES;
         }
-        
-        [self.scrollView setAlpha:0];
+    
         [self.scrollView setFrame:self.view.bounds];
         [self updateScrollViewAndImageViewForCurrentMetrics];
         CGFloat scaling = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;


### PR DESCRIPTION
Fixed issue where double tapping on images causes a flicker in iOS 8. Also fixes animation when presenting image from offscreen.
