### PR TITLE
Fixes static analyzer warning

### DIFF
--- a/Source/JTSAnimatedGIFUtility.m
+++ b/Source/JTSAnimatedGIFUtility.m
@@ -110,7 +110,7 @@ static UIImage *animatedImageWithAnimatedGIFImageSource(CGImageSourceRef const s
     return animation;
 }
 
-static UIImage *animatedImageWithAnimatedGIFReleasingImageSource(CGImageSourceRef source) {
+static UIImage *animatedImageWithAnimatedGIFReleasingImageSource(CGImageSourceRef source CF_CONSUMED) {
     if (source) {
         UIImage *const image = animatedImageWithAnimatedGIFImageSource(source);
         CFRelease(source);


### PR DESCRIPTION
Adds an attribute to tell the compiler we take care of releasing the parameter.
