### PR TITLE
armv7 and arm64-friendly floats

### DIFF
--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -12,6 +12,14 @@
 #import "UIImage+JTSImageEffects.h"
 #import "UIApplication+JTSImageViewController.h"
 
+CG_INLINE CGFLOAT_TYPE JTSImageFloatAbs(CGFLOAT_TYPE aFloat) {
+#if CGFLOAT_IS_DOUBLE
+    return fabs(aFloat);
+#else
+    return fabsf(aFloat);
+#endif
+}
+
 ///--------------------------------------------------------------------------------------------------------------------
 /// Definitions
 ///--------------------------------------------------------------------------------------------------------------------
@@ -1594,7 +1602,7 @@ typedef struct {
     }
     
     CGPoint velocity = [scrollView.panGestureRecognizer velocityInView:scrollView.panGestureRecognizer.view];
-    if (scrollView.zoomScale == 1 && (fabsf(velocity.x) > 1600 || fabsf(velocity.y) > 1600 ) ) {
+    if (scrollView.zoomScale == 1 && (JTSImageFloatAbs(velocity.x) > 1600 || JTSImageFloatAbs(velocity.y) > 1600 ) ) {
         [self dismiss:YES];
     }
 }


### PR DESCRIPTION
Fixed a float conversion warning under arm64. I prefer this method over #58 because this will Do The Right Thing™ on both armv7 and arm64.