### PR TITLE
Disable Snapshot

### DIFF
--- a/Source/JTSImageViewController.h
+++ b/Source/JTSImageViewController.h
@@ -105,6 +105,7 @@ extern CGFloat const JTSImageViewController_DefaultBackgroundBlurRadius;
  Called after the image viewer has finished dismissing.
  */
 - (void)imageViewerDidDismiss:(JTSImageViewController *)imageViewer;
+- (void)imageViewerWillDismiss:(JTSImageViewController *)imageViewer;
 
 @end
 

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -1110,7 +1110,9 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES ;
     _flags.isDismissing = YES;
     
+
     __weak JTSImageViewController *weakSelf = self;
+    [weakSelf.dismissalDelegate imageViewerWillDismiss:weakSelf];
     
     CGFloat duration = JTSImageViewController_TransitionAnimationDuration;
     if (USE_DEBUG_SLOW_ANIMATIONS == 1) {
@@ -1186,6 +1188,7 @@ typedef struct {
                                                     withAnimation:UIStatusBarAnimationFade];
         }
     } completion:^(BOOL finished) {
+        [weakSelf.dismissalDelegate imageViewerWillDismiss:weakSelf];
         [weakSelf.presentingViewController dismissViewControllerAnimated:NO completion:^{
             [weakSelf.dismissalDelegate imageViewerDidDismiss:weakSelf];
         }];
@@ -1240,6 +1243,7 @@ typedef struct {
                                                     withAnimation:UIStatusBarAnimationFade];
         }
     } completion:^(BOOL finished) {
+        [weakSelf.dismissalDelegate imageViewerWillDismiss:weakSelf];
         [weakSelf.presentingViewController dismissViewControllerAnimated:NO completion:^{
             [weakSelf.dismissalDelegate imageViewerDidDismiss:weakSelf];
         }];

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -1019,10 +1019,7 @@ typedef struct {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
 
-    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
-    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
-    [self.snapshotView removeFromSuperview];
-    self.snapshotView = newSnapshotView;
+    [self updateSnapshot];
 
     // Have to dispatch after or else the image view changes above won't be
     // committed prior to the animations below. A single dispatch_async(dispatch_get_main_queue()
@@ -1128,10 +1125,7 @@ typedef struct {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
 
-    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
-    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
-    [self.snapshotView removeFromSuperview];
-    self.snapshotView = newSnapshotView;
+    [self updateSnapshot];
 
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
         
@@ -1176,10 +1170,7 @@ typedef struct {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
 
-    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
-    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
-    [self.snapshotView removeFromSuperview];
-    self.snapshotView = newSnapshotView;
+    [self updateSnapshot];
 
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
         
@@ -1236,10 +1227,7 @@ typedef struct {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
 
-    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
-    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
-    [self.snapshotView removeFromSuperview];
-    self.snapshotView = newSnapshotView;
+    [self updateSnapshot];
 
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
         
@@ -1271,6 +1259,13 @@ typedef struct {
 }
 
 #pragma mark - Snapshots
+
+- (void) updateSnapshot {
+    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
+    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
+    [self.snapshotView removeFromSuperview];
+    self.snapshotView = newSnapshotView;
+}
 
 - (UIView *)snapshotFromParentmostViewController:(UIViewController *)viewController {
     

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -1261,10 +1261,10 @@ typedef struct {
 #pragma mark - Snapshots
 
 - (void) updateSnapshot {
-    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
-    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
-    [self.snapshotView removeFromSuperview];
-    self.snapshotView = newSnapshotView;
+//    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
+//    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
+//    [self.snapshotView removeFromSuperview];
+//    self.snapshotView = newSnapshotView;
 }
 
 - (UIView *)snapshotFromParentmostViewController:(UIViewController *)viewController {

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -1018,7 +1018,12 @@ typedef struct {
     if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillBeginDismissal:withContainerView:)]) {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
-    
+
+    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
+    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
+    [self.snapshotView removeFromSuperview];
+    self.snapshotView = newSnapshotView;
+
     // Have to dispatch after or else the image view changes above won't be
     // committed prior to the animations below. A single dispatch_async(dispatch_get_main_queue()
     // wouldn't work under certain scrolling conditions, so it has to be an ugly
@@ -1122,7 +1127,12 @@ typedef struct {
     if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillBeginDismissal:withContainerView:)]) {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
-    
+
+    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
+    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
+    [self.snapshotView removeFromSuperview];
+    self.snapshotView = newSnapshotView;
+
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
         
         if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillAnimateDismissal:withContainerView:duration:)]) {
@@ -1165,7 +1175,12 @@ typedef struct {
     if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillBeginDismissal:withContainerView:)]) {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
-    
+
+    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
+    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
+    [self.snapshotView removeFromSuperview];
+    self.snapshotView = newSnapshotView;
+
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
         
         if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillAnimateDismissal:withContainerView:duration:)]) {
@@ -1220,7 +1235,12 @@ typedef struct {
     if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillBeginDismissal:withContainerView:)]) {
         [weakSelf.animationDelegate imageViewerWillBeginDismissal:weakSelf withContainerView:weakSelf.view];
     }
-    
+
+    UIView *newSnapshotView = [self snapshotFromViewController:self.presentingViewController];
+    [self.view insertSubview: newSnapshotView aboveSubview: self.snapshotView];
+    [self.snapshotView removeFromSuperview];
+    self.snapshotView = newSnapshotView;
+
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
         
         if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillAnimateDismissal:withContainerView:duration:)]) {
@@ -1256,7 +1276,11 @@ typedef struct {
     
     UIViewController *presentingViewController = viewController.view.window.rootViewController;
     while (presentingViewController.presentedViewController) presentingViewController = presentingViewController.presentedViewController;
-    UIView *snapshot = [presentingViewController.view snapshotViewAfterScreenUpdates:YES];
+    return [self snapshotFromViewController:presentingViewController];
+}
+
+- (UIView *)snapshotFromViewController:(UIViewController *)viewController {
+    UIView *snapshot = [viewController.view snapshotViewAfterScreenUpdates:YES];
     snapshot.clipsToBounds = NO;
     return snapshot;
 }

--- a/Source/JTSImageViewController.m
+++ b/Source/JTSImageViewController.m
@@ -1094,7 +1094,8 @@ typedef struct {
                     [[UIApplication sharedApplication] setStatusBarHidden:_startingInfo.statusBarHiddenPriorToPresentation
                                                             withAnimation:UIStatusBarAnimationNone];
                 }
-                
+
+                [weakSelf.dismissalDelegate imageViewerWillDismiss:weakSelf];
                 [weakSelf.presentingViewController dismissViewControllerAnimated:NO completion:^{
                     [weakSelf.dismissalDelegate imageViewerDidDismiss:weakSelf];
                 }];


### PR DESCRIPTION
Taking a snapshot of the presenting view controller caused a layout bug when dismissing `JTSImageViewController` in landscape mode from a Stream. Removing the snapshot update fixes this issue. I'm not sure what problems this may introduce. @colinta / @rynbyjn what might I be missing?