### PR TITLE
Fixed +imageURLIsAGIF:

### DIFF
--- a/Source/JTSAnimatedGIFUtility.m
+++ b/Source/JTSAnimatedGIFUtility.m
@@ -21,7 +21,7 @@
 @implementation JTSAnimatedGIFUtility
 
 + (BOOL)imageURLIsAGIF:(NSString *)imageURL {
-    return [[imageURL substringFromIndex:[imageURL length] - 3] isEqualToString:@"gif"];
+    return (NSOrderedSame == [imageURL.pathExtension caseInsensitiveCompare:@"gif"]);
 }
 
 static int delayCentisecondsForImageAtIndex(CGImageSourceRef const source, size_t const i) {


### PR DESCRIPTION
+ Fixed crash when `imageURL.length` is less than 3
+ Case insensitive comparing "gif" URL extension 