### PR TITLE
Support for a custom downloader and delegate to provide them

### DIFF
--- a/JTSImageViewController.podspec
+++ b/JTSImageViewController.podspec
@@ -1,11 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "JTSImageViewController"
-  s.version      = "1.5.1"
+  s.version      = "1.5.2"
   s.summary      = "An interactive iOS image viewer that does it all: double tap to zoom, flick to dismiss, et cetera."
-  s.homepage     = "https://github.com/jaredsinclair/JTSImageViewController"
+  s.homepage     = "https://github.com/brucehappy/JTSImageViewController"
   s.license      = { :type => 'MIT', :file => 'LICENSE'  }
-  s.author       = { "Jared Sinclair" => "desk@jaredsinclair.com" }
-  s.source       = { :git => "https://github.com/jaredsinclair/JTSImageViewController.git", :tag => s.version.to_s }
+  s.authors      = { "Jared Sinclair" => "desk@jaredsinclair.com",
+                     "Bruce Duncan" => "bduncan@rassilon.co" }
+  s.source       = { :git => "https://github.com/brucehappy/JTSImageViewController.git", :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
   s.frameworks   = 'UIKit', 'ImageIO', 'Accelerate'

--- a/Sample App/JTSImageVC/JTSImageVC/JTSViewController.m
+++ b/Sample App/JTSImageVC/JTSImageVC/JTSViewController.m
@@ -12,6 +12,7 @@
 #import "JTSImageInfo.h"
 
 #define TRY_AN_ANIMATED_GIF 0
+#define TRY_AN_IMAGE_URL 0
 
 @interface JTSViewController ()
 
@@ -37,7 +38,9 @@
     // Create image info
     JTSImageInfo *imageInfo = [[JTSImageInfo alloc] init];
 #if TRY_AN_ANIMATED_GIF == 1
-    imageInfo.imageURL = [NSURL URLWithString:@"http://media.giphy.com/media/O3QpFiN97YjJu/giphy.gif"];
+    imageInfo.imageURL = [NSURL URLWithString:@"https://media.giphy.com/media/O3QpFiN97YjJu/giphy.gif"];
+#elif TRY_AN_IMAGE_URL == 1
+    imageInfo.imageURL = [NSURL URLWithString:@"https://upload.wikimedia.org/wikipedia/commons/6/67/Inside_the_Batad_rice_terraces.jpg"];
 #else
     imageInfo.image = self.bigImageButton.image;
 #endif

--- a/Source/JTSImageViewController.h
+++ b/Source/JTSImageViewController.h
@@ -19,6 +19,8 @@
 @protocol JTSImageViewControllerInteractionsDelegate;
 @protocol JTSImageViewControllerAccessibilityDelegate;
 @protocol JTSImageViewControllerAnimationDelegate;
+@protocol JTSImageViewControllerDownloader;
+@protocol JTSImageViewControllerDownloaderDelegate;
 
 typedef NS_ENUM(NSInteger, JTSImageViewControllerMode) {
     JTSImageViewControllerMode_Image,
@@ -63,8 +65,10 @@ extern CGFloat const JTSImageViewController_DefaultBackgroundBlurRadius;
 
 @property (weak, nonatomic, readwrite) id <JTSImageViewControllerAnimationDelegate> animationDelegate;
 
+@property (weak, nonatomic, readonly) id <JTSImageViewControllerDownloaderDelegate> downloaderDelegate;
+
 /**
- Designated initializer.
+ Convenience initializer.
  
  @param imageInfo The source info for image and transition metadata. Required.
  
@@ -76,6 +80,25 @@ extern CGFloat const JTSImageViewController_DefaultBackgroundBlurRadius;
 - (instancetype)initWithImageInfo:(JTSImageInfo *)imageInfo
                              mode:(JTSImageViewControllerMode)mode
                   backgroundStyle:(JTSImageViewControllerBackgroundOptions)backgroundOptions;
+
+/**
+ Designated initializer.
+ 
+ @param imageInfo The source info for image and transition metadata. Required.
+ 
+ @param mode The mode to be used. (JTSImageViewController has an alternate alt text mode). Required.
+ 
+ @param backgroundStyle Currently, either scaled-and-dimmed, or scaled-dimmed-and-blurred.
+ The latter is like Tweetbot 3.0's background style.
+ 
+ @param downloaderDelegate The downloaderDelegate to be used. Optional.
+ */
+
+- (instancetype)initWithImageInfo:(JTSImageInfo *)imageInfo
+                             mode:(JTSImageViewControllerMode)mode
+                  backgroundStyle:(JTSImageViewControllerBackgroundOptions)backgroundOptions
+               downloaderDelegate:(id <JTSImageViewControllerDownloaderDelegate>)downloaderDelegate;
+
 
 /**
  JTSImageViewController is presented from viewController as a UIKit modal view controller.
@@ -226,6 +249,51 @@ extern CGFloat const JTSImageViewController_DefaultBackgroundBlurRadius;
 - (void)imageViewerWillBeginDismissal:(JTSImageViewController *)imageViewer withContainerView:(UIView *)containerView;
 
 - (void)imageViewerWillAnimateDismissal:(JTSImageViewController *)imageViewer withContainerView:(UIView *)containerView duration:(CGFloat)duration;
+
+@end
+
+///---------------------------------------------------------------------------------------------------
+/// Downloader
+///---------------------------------------------------------------------------------------------------
+
+@protocol JTSImageViewControllerDownloader <NSObject>
+
+/**
+ The number of bytes that are expected to be recieved.
+ */
+@property (readonly) int64_t countOfBytesExpectedToReceive;
+
+/**
+ The number of bytes that have been received.
+ */
+@property (readonly) int64_t countOfBytesReceived;
+
+/**
+ Called to begin downloading the image.
+ 
+ Calls block with non-nil value on success, and nil on failure.
+ */
+- (void)downloadImage:(void (^)(UIImage *image))completion;
+
+@optional
+
+/**
+ Called to cancel the download if it is in progress.
+ */
+- (void)cancel;
+
+@end
+
+///---------------------------------------------------------------------------------------------------
+/// Downloader Delegate
+///---------------------------------------------------------------------------------------------------
+
+@protocol JTSImageViewControllerDownloaderDelegate <NSObject>
+
+/**
+ Called to retrieve a downloader for the given image information.
+ */
+- (id <JTSImageViewControllerDownloader>)downloaderForImageInfo:(JTSImageInfo *)imageInfo;
 
 @end
 


### PR DESCRIPTION
Currently, image downloading within the framework is handled by two static functions on ``JTSSimpleImageDownloader``, called from the ``JTSImageViewController`` without a means of override or customization.  This PR refactors the existing downloading process to utilize two protocols:

1. ``JTSImageViewControllerDownloadDelegate`` - A delegate which provides instances of a downloader
2. ``JTSImageViewControllerDownloader`` - A downloader which handles downloading the image and provides progress updates

The changes are backwards compatible with 1.5.1, and everything continues to work exactly the same as it has out-of-the-box.  This compatibility is accomplished by providing default implementations of the protocols which use the existing downloader when one is not supplied by the user.  These protocols can be used to easily provide a custom downloader within the framework.  For instance, in my current project I have implemented the delegate and downloader using Alamofire to call a REST API, passing custom headers for Authorization, etc., and also interfacing with a caching system that was already in use within the project.

You will likely not want to bring in the changed pod spec, for obvious reasons.  Please let me know if there are any other issues with the PR.