### PR TITLE
Fix incorrectly named parameter in method documentation

### DIFF
--- a/Source/JTSImageViewController.h
+++ b/Source/JTSImageViewController.h
@@ -70,7 +70,7 @@ extern CGFloat const JTSImageViewController_DefaultBackgroundBlurRadius;
  
  @param mode The mode to be used. (JTSImageViewController has an alternate alt text mode). Required.
  
- @param backgroundStyle Currently, either scaled-and-dimmed, or scaled-dimmed-and-blurred. 
+ @param backgroundOptions Currently, either scaled-and-dimmed, or scaled-dimmed-and-blurred.
  The latter is like Tweetbot 3.0's background style.
  */
 - (instancetype)initWithImageInfo:(JTSImageInfo *)imageInfo


### PR DESCRIPTION
Attempting to purge our app of warnings and this was a simple fix